### PR TITLE
Fixes a bug where the value of an options key is an empty array that …

### DIFF
--- a/lib/html_attributes/rails/tag_helper.rb
+++ b/lib/html_attributes/rails/tag_helper.rb
@@ -12,7 +12,7 @@ module HtmlAttributes #:nodoc:
     end
 
     def tag_options_with_html_attributes(options, escape = true) #:nodoc:
-      options = ::Hash[*options.map { |key, value| [key, value.respond_to?("to_#{key}_attr") ? value.send("to_#{key}_attr") : value] }.flatten] unless options.blank?
+      options = ::Hash[options.map { |key, value| [key, value.respond_to?("to_#{key}_attr") ? value.send("to_#{key}_attr") : value] }] unless options.blank?
       tag_options_without_html_attributes(options, escape)
     end
 


### PR DESCRIPTION
…was removed by `.flatten`. This in turn resulted in an error while initializing Hash with “odd number of arguments for Hash”.

Consider this as an example for the options that lead to the above mentioned error:
`{ class: "some-class", value: []}`

@serevaris @jansiwy Please review.
