### PR TITLE
Add support for ails 5.1

### DIFF
--- a/html_attributes.gemspec
+++ b/html_attributes.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.version       = HtmlAttributes::VERSION
   gem.platform      = Gem::Platform::RUBY
 
-  gem.add_dependency             "actionview", ">= 4.0", "< 5.2"
+  gem.add_dependency             "actionview", "~> 5.1"
 
   gem.add_development_dependency "rspec"
 

--- a/html_attributes.gemspec
+++ b/html_attributes.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.version       = HtmlAttributes::VERSION
   gem.platform      = Gem::Platform::RUBY
 
-  gem.add_dependency             "actionview", "~> 5.1"
+  gem.add_dependency             "actionview", ">= 4.0", "< 5.2"
 
   gem.add_development_dependency "rspec"
 

--- a/lib/html_attributes.rb
+++ b/lib/html_attributes.rb
@@ -5,9 +5,7 @@ if defined?(ActionView::Helpers::TagHelper)
 
   require "html_attributes/rails/tag_helper"
 
-  ActionView::Helpers::TagHelper.module_eval do
-    include HtmlAttributes::TagHelper
-  end
+  ActionView::Helpers::TagHelper::TagBuilder.send(:include, HtmlAttributes::TagHelper)
 
   ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.merge(::HtmlAttributes::BOOLEAN_ATTRIBUTES)
   ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.merge(ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.map(&:to_sym))

--- a/lib/html_attributes.rb
+++ b/lib/html_attributes.rb
@@ -5,9 +5,14 @@ if defined?(ActionView::Helpers::TagHelper)
 
   require "html_attributes/rails/tag_helper"
 
-  ActionView::Helpers::TagHelper::TagBuilder.send(:include, HtmlAttributes::TagHelper)
+  if Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR >= 1
+    ActionView::Helpers::TagHelper::TagBuilder.send(:include, HtmlAttributes::TagHelper)
+  else
+    ActionView::Helpers::TagHelper.module_eval do
+      include HtmlAttributes::TagHelper
+    end
+  end
 
   ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.merge(::HtmlAttributes::BOOLEAN_ATTRIBUTES)
   ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.merge(ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.map(&:to_sym))
-
 end

--- a/lib/html_attributes/rails/tag_helper.rb
+++ b/lib/html_attributes/rails/tag_helper.rb
@@ -8,8 +8,8 @@ module HtmlAttributes #:nodoc:
   module TagHelper #:nodoc:
 
     def self.included(base) #:nodoc:
-      base.alias_method :tag_options_without_html_attributes, :tag_options
-      base.alias_method :tag_options, :tag_options_with_html_attributes
+      base.send :alias_method, :tag_options_without_html_attributes, :tag_options
+      base.send :alias_method, :tag_options, :tag_options_with_html_attributes
     end
 
     def tag_options_with_html_attributes(options, escape = true) #:nodoc:

--- a/lib/html_attributes/rails/tag_helper.rb
+++ b/lib/html_attributes/rails/tag_helper.rb
@@ -8,8 +8,8 @@ module HtmlAttributes #:nodoc:
   module TagHelper #:nodoc:
 
     def self.included(base) #:nodoc:
-      base.send :alias_method, :tag_options_without_html_attributes, :tag_options
-      base.send :alias_method, :tag_options, :tag_options_with_html_attributes
+      base.send(:alias_method, :tag_options_without_html_attributes, :tag_options)
+      base.send(:alias_method, :tag_options, :tag_options_with_html_attributes)
     end
 
     def tag_options_with_html_attributes(options, escape = true) #:nodoc:

--- a/lib/html_attributes/version.rb
+++ b/lib/html_attributes/version.rb
@@ -1,11 +1,11 @@
 module HtmlAttributes
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 
   module Version
     version = VERSION.to_s.split(".").map { |i| i.to_i }
     MAJOR = version[0]
     MINOR = version[1]
-    PATCH = version[2]
+    PATCH = version[3]
     STRING = "#{MAJOR}.#{MINOR}.#{PATCH}"
   end
 


### PR DESCRIPTION
in Rails5.1 the tag_options method moved from `ActionView::Helpers::TagHelper` module to `ActionView::Helpers::TagHelper::TagBuilder` class 

https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/tag_helper.rb#L59
